### PR TITLE
パラメタのキーが無かったのを修正

### DIFF
--- a/lib/channel_id_to_name.ex
+++ b/lib/channel_id_to_name.ex
@@ -17,7 +17,7 @@ defmodule ChannelIdToName do
   end
 
   defp gen_url(channel_id, api_key) do
-    "/youtube/v3/channels?part=snippet&key=" <> api_key <> channel_id
+    "/youtube/v3/channels?part=snippet&key=" <> api_key <> "&id=" <> channel_id
   end
 
   defp fetch_title(data) do


### PR DESCRIPTION
APIのパラメタ文字列の中で```"&id="```が抜けていたのを修正。
今まで誤ってAPIキーの方に```"&id="```を含めてテスト実行していたので動いていた。